### PR TITLE
Bug: Couldn't get filename which redirect

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "go",
             "request": "launch",
             "mode": "auto",
-            "program": "${fileDirname}",
+            "program": "${workspaceFolder}/cmd/workplace-sync/",
             "args": [
                 "-host",
                 "ws.hdev.io",
@@ -21,7 +21,7 @@
             "type": "go",
             "request": "launch",
             "mode": "auto",
-            "program": "${workspaceFolder}/cmd/",
+            "program": "${workspaceFolder}/cmd/workplace-sync/",
             "args": [
                 "-local",
                 "C:\\DEV\\workplace-sync\\sample.json",
@@ -29,14 +29,16 @@
             ]
         },
         {
-            "name": "Local Interactive",
+            "name": "Local install app",
             "type": "go",
             "request": "launch",
             "mode": "auto",
-            "program": "${workspaceFolder}/cmd/",
+            "program": "${workspaceFolder}/cmd/workplace-sync/",
             "args": [
                 "-local",
-                "C:\\DEV\\workplace-sync\\sample.json"
+                "C:\\DEV\\workplace-sync\\sample.json",
+                "-name",
+                "mkcert"
             ]
         }
     ]

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -29,9 +29,14 @@ func Get(link config.Link, dir string) error {
 
 	// shot urls are redirected to the actual file https://app/latest -> https://app/1.0.0.zip
 	if resp.Request != nil && resp.Request.Response != nil && path.Ext(link.Url) == "" {
-		l, err := resp.Request.Response.Location()
-		if err == nil {
-			file = path.Base(l.String())
+		r := resp.Request.Referer()
+		if r != "" && strings.HasSuffix(r, ".exe") {
+			file = path.Base(r)
+		} else {
+			l, err := resp.Request.Response.Location()
+			if err == nil {
+				file = path.Base(l.String())
+			}
 		}
 	}
 

--- a/sample.json
+++ b/sample.json
@@ -121,11 +121,6 @@
             "version": "7.1.0-51"
         },
         {
-            "name": "mkcert",
-            "url": "https://github.com/FiloSottile/mkcert/releases/download/v1.4.4/mkcert-v1.4.4-windows-amd64.exe",
-            "version": "v1.4.4"
-        },
-        {
             "name": "cloc",
             "url": "https://github.com/AlDanial/cloc/releases/download/v1.94/cloc-1.94.exe",
             "version": "v1.94"


### PR DESCRIPTION
```
mkcert-v1.4.4-windows-amd64.exe 100% |█████████████████████████████████████████████████| (4.7/4.7 MB, 3.5 MB/s)
  ERROR   link https://dl.filippo.io/mkcert/latest?for=windows/amd64, folder: c:\ws\, error: open c:\ws\b26211b2-0c9b-408a-8e36-c3221826af3a?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20221120%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20221120T114653Z&X-Amz-Expires=300&X-Amz-Signature=8cd3272cb31f543e1a270f3f06c923df1bf422f6a3d01aa1a105f9b110e69668&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=138547797&response-content-disposition=attachment%3B%20filename%3Dmkcert-v1.4.4-windows-amd64.exe&response-content-type=application%2Foctet-stream.tmp: The filename, directory name, or volume label syntax is incorrect.
```

Use resp.Request.Response.Location() and resp.Request.Response.Location() to get destination file name.